### PR TITLE
[SAFE-445] add authType by default on addApiConfiguration

### DIFF
--- a/src/schema/mutation/addApiConfiguration.ts
+++ b/src/schema/mutation/addApiConfiguration.ts
@@ -3,7 +3,7 @@ import errors from '../../const/errors';
 import { ApiConfiguration } from '../../models';
 import { ApiConfigurationType } from '../types';
 import { AppAbility } from '../../security/defineAbilityFor';
-import { status } from '../../const/enumTypes';
+import { authType, status } from '../../const/enumTypes';
 
 export default {
     /*  Creates a new apiConfiguration.
@@ -24,6 +24,7 @@ export default {
                 const apiConfiguration = new ApiConfiguration({
                     name: args.name,
                     status: status.pending,
+                    authType: authType.serviceToService,
                     permissions: {
                         canSee: [],
                         canCreate: [],


### PR DESCRIPTION
# Description

I added a default type to Api Configuration using graphQL Enum type.


## Type of change

Please delete options that are not relevant.

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] In the front-end, I created an API configuration to test it everything was fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
