### PR TITLE
AB#11477

### DIFF
--- a/__tests__/jest.setup.ts
+++ b/__tests__/jest.setup.ts
@@ -9,7 +9,8 @@ let request: any;
 // Execute before all tests.
 beforeAll(async () => {
   await startDatabase();
-  server = new SafeTestServer(schema);
+  server = new SafeTestServer();
+  await server.start(schema);
   request = supertest(server.app);
 });
 

--- a/__tests__/server.setup.ts
+++ b/__tests__/server.setup.ts
@@ -18,11 +18,7 @@ class SafeTestServer {
 
   public status = new EventEmitter();
 
-  constructor(schema: GraphQLSchema) {
-    this.start(schema);
-  }
-
-  public start(schema: GraphQLSchema): void {
+  public async start(schema: GraphQLSchema): Promise<void> {
     // === EXPRESS ===
     this.app = express();
 
@@ -33,7 +29,7 @@ class SafeTestServer {
     this.app.use('/graphql', graphqlUploadExpress({ maxFileSize: 7340032, maxFiles: 10 }));
 
     // === APOLLO ===
-    this.apolloServer = apollo(schema);
+    this.apolloServer = await apollo(schema);
     this.apolloServer.applyMiddleware({ app: this.app });
 
     // === SUBSCRIPTIONS ===

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@casl/ability": "^5.2.2",
         "@casl/mongoose": "^5.0.0",
         "amqplib": "^0.8.0",
+        "apollo-datasource-rest": "^3.4.0",
         "apollo-server-core": "^2.25.2",
         "apollo-server-express": "^2.19.0",
         "body-parser": "^1.19.0",
@@ -2225,6 +2226,75 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/apollo-datasource-rest": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-3.4.0.tgz",
+      "integrity": "sha512-biv7jKykXV1g9Ans5FEUOTxpN7hx+ii5xMjI5wDUyqj0eFalU6Zry/7DFGVxTelHUcemoVKFTeHJb6lz80mxrg==",
+      "dependencies": {
+        "apollo-datasource": "^3.3.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0",
+        "apollo-server-errors": "^3.3.0",
+        "http-cache-semantics": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest/node_modules/apollo-datasource": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.0.tgz",
+      "integrity": "sha512-It8POTZTOCAnedRj2izEVeySN06LIfojigZjWaOY7voLe0DIgtvhql91xr27fuIWsR/Ew9twO3dLBjjvy34J4Q==",
+      "dependencies": {
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest/node_modules/apollo-server-caching": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+      "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest/node_modules/apollo-server-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.0.tgz",
+      "integrity": "sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest/node_modules/apollo-server-errors": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.0.tgz",
+      "integrity": "sha512-9/MNlPZBbEjcCdJcUSbKbVEBT9xZS8GSpX7T/TyzcxHSbsXJszSDSipQNGC+PRKTKAUnv61IONScVyLKEZ5XEQ==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest/node_modules/graphql": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.0.1.tgz",
+      "integrity": "sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/apollo-graphql": {
@@ -6329,8 +6399,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "node_modules/http-errors": {
       "version": "1.8.0",
@@ -14236,6 +14305,57 @@
         "apollo-server-env": "^3.1.0"
       }
     },
+    "apollo-datasource-rest": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-3.4.0.tgz",
+      "integrity": "sha512-biv7jKykXV1g9Ans5FEUOTxpN7hx+ii5xMjI5wDUyqj0eFalU6Zry/7DFGVxTelHUcemoVKFTeHJb6lz80mxrg==",
+      "requires": {
+        "apollo-datasource": "^3.3.0",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.0",
+        "apollo-server-errors": "^3.3.0",
+        "http-cache-semantics": "^4.1.0"
+      },
+      "dependencies": {
+        "apollo-datasource": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-3.3.0.tgz",
+          "integrity": "sha512-It8POTZTOCAnedRj2izEVeySN06LIfojigZjWaOY7voLe0DIgtvhql91xr27fuIWsR/Ew9twO3dLBjjvy34J4Q==",
+          "requires": {
+            "apollo-server-caching": "^3.3.0",
+            "apollo-server-env": "^4.2.0"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz",
+          "integrity": "sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-4.2.0.tgz",
+          "integrity": "sha512-4xJ+PCoWsFLj4rU6iXrIhqD7nI42goi4Iqrhsof9680ljSzkzd+PCwZsja3mHOFXKUQQUvJ7StVSgwaiRu45+A==",
+          "requires": {
+            "node-fetch": "^2.6.1"
+          }
+        },
+        "apollo-server-errors": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-3.3.0.tgz",
+          "integrity": "sha512-9/MNlPZBbEjcCdJcUSbKbVEBT9xZS8GSpX7T/TyzcxHSbsXJszSDSipQNGC+PRKTKAUnv61IONScVyLKEZ5XEQ==",
+          "requires": {}
+        },
+        "graphql": {
+          "version": "16.0.1",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.0.1.tgz",
+          "integrity": "sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==",
+          "peer": true
+        }
+      }
+    },
     "apollo-graphql": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.3.tgz",
@@ -17630,8 +17750,7 @@
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@casl/ability": "^5.2.2",
     "@casl/mongoose": "^5.0.0",
     "amqplib": "^0.8.0",
+    "apollo-datasource-rest": "^3.4.0",
     "apollo-server-core": "^2.25.2",
     "apollo-server-express": "^2.19.0",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-typescript": "^14.0.1",
-    "eslint-plugin-import": "^2.25.2",
     "husky": "^7.0.1",
     "jest": "^27.0.4",
     "nodemon": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-typescript": "^14.0.1",
+    "eslint-plugin-import": "^2.25.2",
     "husky": "^7.0.1",
     "jest": "^27.0.4",
     "nodemon": "^2.0.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,8 @@ const getSchema = async () => {
 
 const launchServer = async () => {
   const liveSchema = await getSchema();
-  const safeServer = new SafeServer(liveSchema);
+  const safeServer = new SafeServer();
+  await safeServer.start(liveSchema);
   safeServer.httpServer.listen(PORT, () => {
     console.log(`🚀 Server ready at http://localhost:${PORT}/${safeServer.apolloServer.graphqlPath}`);
     console.log(`🚀 Server ready at ws://localhost:${PORT}/${safeServer.apolloServer.subscriptionsPath}`);

--- a/src/schema/types/record.ts
+++ b/src/schema/types/record.ts
@@ -4,7 +4,7 @@ import { canAccessContent } from '../../security/accessFromApplicationPermission
 import GraphQLJSON from 'graphql-type-json';
 import { FormType, UserType, VersionType } from '.';
 import { Form, Resource, Record, Version, User } from '../../models';
-import { CustomAPI } from '../../server/apollo/dataSources';
+import getDisplayText from '../../utils/form/getDisplayText';
 
 export const RecordType = new GraphQLObjectType({
   name: 'Record',
@@ -32,10 +32,9 @@ export const RecordType = new GraphQLObjectType({
       type: GraphQLJSON,
       args: {
         display: { type: GraphQLBoolean },
-        showTextChoices: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
-        if (args.display || args.showTextChoices) {
+        if (args.display) {
           const source = parent.resource ? await Resource.findById(parent.resource) : await Form.findById(parent.form);
           if (source) {
             const res = {};
@@ -44,7 +43,7 @@ export const RecordType = new GraphQLObjectType({
               if (parent.data[name]) {
                 res[name] = parent.data[name];
                 // Get the display field from the linked record if any
-                if (args.display && field.resource && field.displayField) {
+                if (field.resource && field.displayField) {
                   try {
                     const record = await Record.findOne({ _id: parent.data[name], archived: { $ne: true } });
                     res[name] = record.data[field.displayField];
@@ -53,30 +52,8 @@ export const RecordType = new GraphQLObjectType({
                   }
                 }
                 // Get the text instead of the value for choices, fetch it if needed.
-                if (args.showTextChoices && (field.choices || field.choicesByUrl)) {
-                  let choices: any[] = field.choices;
-                  if (field.choicesByUrl) {
-                    const url: string = field.choicesByUrl.url;
-                    if (url.includes('http://localhost:3000/') || url.includes('{SAFE_API}')) {
-                      const safeURL: string = url.includes('http://localhost:3000/') ? 'http://localhost:3000/' : '{SAFE_API}';
-                      const endpointArray: string[] = url.substring(url.indexOf(safeURL) + safeURL.length).split('/');
-                      const apiName: string = endpointArray.shift();
-                      const endpoint: string = endpointArray.join('/');
-                      const dataSource: CustomAPI = context.dataSources[apiName];
-                      if (dataSource) {
-                        choices = await dataSource.getChoices(endpoint, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
-                      }
-                    } else {
-                      const dataSource: CustomAPI = context.dataSources._rest;
-                      choices = await dataSource.getChoices(url, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
-                    }
-                  }
-                  if (choices && choices.length) {
-                    const choice = choices.find(x => x.value ? x.value === res[name] : x === res[name]);
-                    if (choice && choice.text) {
-                      res[name] = choice.text;
-                    }
-                  }
+                if (field.choices || field.choicesByUrl) {
+                  res[name] = await getDisplayText(field, parent.data[name], context);
                 }
               } else {
                 res[name] = null;

--- a/src/schema/types/record.ts
+++ b/src/schema/types/record.ts
@@ -4,6 +4,7 @@ import { canAccessContent } from '../../security/accessFromApplicationPermission
 import GraphQLJSON from 'graphql-type-json';
 import { FormType, UserType, VersionType } from '.';
 import { Form, Resource, Record, Version, User } from '../../models';
+import { CustomAPI } from '../../server/apollo/dataSources';
 
 export const RecordType = new GraphQLObjectType({
   name: 'Record',
@@ -31,37 +32,60 @@ export const RecordType = new GraphQLObjectType({
       type: GraphQLJSON,
       args: {
         display: { type: GraphQLBoolean },
+        showTextChoices: { type: GraphQLBoolean },
       },
-      async resolve(parent, args) {
-        if (args.display) {
+      async resolve(parent, args, context) {
+        if (args.display || args.showTextChoices) {
           const source = parent.resource ? await Resource.findById(parent.resource) : await Form.findById(parent.form);
-          const res = {};
           if (source) {
+            const res = {};
             for (const field of source.fields) {
               const name = field.name;
               if (parent.data[name]) {
                 res[name] = parent.data[name];
-                if (field.resource && field.displayField) {
+                // Get the display field from the linked record if any
+                if (args.display && field.resource && field.displayField) {
                   try {
                     const record = await Record.findOne({ _id: parent.data[name], archived: { $ne: true } });
                     res[name] = record.data[field.displayField];
                   } catch {
                     res[name] = null;
                   }
-                } else {
-                  res[name] = parent.data[name];
+                }
+                // Get the text instead of the value for choices, fetch it if needed.
+                if (args.showTextChoices && (field.choices || field.choicesByUrl)) {
+                  let choices: any[] = field.choices;
+                  if (field.choicesByUrl) {
+                    const url: string = field.choicesByUrl.url;
+                    if (url.includes('http://localhost:3000/') || url.includes('{SAFE_API}')) {
+                      const safeURL: string = url.includes('http://localhost:3000/') ? 'http://localhost:3000/' : '{SAFE_API}';
+                      const endpointArray: string[] = url.substring(url.indexOf(safeURL) + safeURL.length).split('/');
+                      const apiName: string = endpointArray.shift();
+                      const endpoint: string = endpointArray.join('/');
+                      const dataSource: CustomAPI = context.dataSources[apiName];
+                      if (dataSource) {
+                        choices = await dataSource.getChoices(endpoint, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
+                      }
+                    } else {
+                      const dataSource: CustomAPI = context.dataSources._rest;
+                      choices = await dataSource.getChoices(url, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
+                    }
+                  }
+                  if (choices && choices.length) {
+                    const choice = choices.find(x => x.value ? x.value === res[name] : x === res[name]);
+                    if (choice && choice.text) {
+                      res[name] = choice.text;
+                    }
+                  }
                 }
               } else {
                 res[name] = null;
               }
             }
             return res;
-          } else {
-            return parent.data;
           }
-        } else {
-          return parent.data;
         }
+        return parent.data;
       },
     },
     versions: {

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -3,26 +3,65 @@ import { DataSources } from 'apollo-server-core/dist/graphqlOptions';
 import { status } from '../../const/enumTypes';
 import { ApiConfiguration } from '../../models';
 import { getToken } from '../../utils/proxy';
+import { get } from 'lodash';
 
-export default async (): Promise<() => DataSources<any>> => {
-  const apiConfigurations = await ApiConfiguration.find({ status: status.active });
-  return () => apiConfigurations.reduce((o, apiConfiguration) => {
-    return { ...o, [apiConfiguration.name]: new CustomAPI(apiConfiguration)}
-  }, {});
-};
-
-class CustomAPI extends RESTDataSource {
+/**
+ * CustomAPI class to create a dataSource fetching from an APIConfiguration.
+ * If nothing is passed in the constructor, it will only be a standard REST DataSource.
+ */
+export class CustomAPI extends RESTDataSource {
 
   public apiConfiguration: ApiConfiguration;
-
-  constructor(apiConfiguration: ApiConfiguration) {
+  
+  /**
+   * Construct a CustomAPI.
+   * @param apiConfiguration optional argument used to initialize the calls using the passed ApiConfiguration
+   */
+  constructor(apiConfiguration?: ApiConfiguration) {
     super();
-    this.apiConfiguration = apiConfiguration;
-    this.baseURL = this.apiConfiguration.endpoint;
+    if (apiConfiguration) {
+      this.apiConfiguration = apiConfiguration;
+      this.baseURL = this.apiConfiguration.endpoint;
+    }
   }
 
+  /**
+   * Pass auth token if needed.
+   * @param request request sent.
+   */
   async willSendRequest(request: RequestOptions) {
-    const token: string = await getToken(this.apiConfiguration);
-    request.headers.set('Authorization', token);
+    if (this.apiConfiguration) {
+      const token: string = await getToken(this.apiConfiguration);
+      request.headers.set('Authorization', `Bearer ${token}`);
+    }
+  }
+
+  /**
+   * Fetch choices from endpoint and return an array of value and text using parameters.
+   * @param enpoint enpoint used to fetch the data.
+   * @param path path to the array of result in the request response.
+   * @param value path to the value used for choices.
+   * @param text path to the text used for choices.
+   */
+  async getChoices(endpoint: string, path: string, value: string, text: string): Promise<{ value: any, text: string }[]> {
+    const res = await this.get(endpoint);
+    const choices = path ? [...get(res, path)] : [...res];
+    return choices ? choices.map((x: any) => ({
+      value: value ? get(x, value) : x,
+      text: text ? get(x, text) : value ? get(x, value) : x,
+    })) : [];
   }
 }
+
+/**
+ * Create a data source for each active apiConfiguration. Create also an additional one for classic REST requests.
+ */
+export default async (): Promise<() => DataSources<any>> => {
+  const apiConfigurations = await ApiConfiguration.find({ status: status.active });
+  return () => ({
+    ...apiConfigurations.reduce((o, apiConfiguration) => {
+      return { ...o, [apiConfiguration.name]: new CustomAPI(apiConfiguration) };
+    }, {}),
+    _rest: new CustomAPI() });
+};
+

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -1,0 +1,28 @@
+import { RequestOptions, RESTDataSource } from 'apollo-datasource-rest';
+import { DataSources } from 'apollo-server-core/dist/graphqlOptions';
+import { status } from '../../const/enumTypes';
+import { ApiConfiguration } from '../../models';
+import { getToken } from '../../utils/proxy';
+
+export default async (): Promise<() => DataSources<any>> => {
+  const apiConfigurations = await ApiConfiguration.find({ status: status.active });
+  return () => apiConfigurations.reduce((o, apiConfiguration) => {
+    return { ...o, [apiConfiguration.name]: new CustomAPI(apiConfiguration)}
+  }, {});
+};
+
+class CustomAPI extends RESTDataSource {
+
+  public apiConfiguration: ApiConfiguration;
+
+  constructor(apiConfiguration: ApiConfiguration) {
+    super();
+    this.apiConfiguration = apiConfiguration;
+    this.baseURL = this.apiConfiguration.endpoint;
+  }
+
+  async willSendRequest(request: RequestOptions) {
+    const token: string = await getToken(this.apiConfiguration);
+    request.headers.set('Authorization', token);
+  }
+}

--- a/src/server/apollo/index.ts
+++ b/src/server/apollo/index.ts
@@ -1,9 +1,10 @@
 import { ApolloServer } from 'apollo-server-express';
 import { GraphQLSchema } from 'graphql';
 import context from './context';
+import dataSources from './dataSources';
 import onConnect from './onConnect';
 
-export default (apiSchema: GraphQLSchema) => new ApolloServer({
+export default async (apiSchema: GraphQLSchema): Promise<ApolloServer> => new ApolloServer({
   uploads: false,
   schema: apiSchema,
   introspection: true,
@@ -12,4 +13,5 @@ export default (apiSchema: GraphQLSchema) => new ApolloServer({
     onConnect: onConnect,
   },
   context: context,
+  dataSources: await dataSources(),
 });

--- a/src/server/apollo/index.ts
+++ b/src/server/apollo/index.ts
@@ -4,7 +4,12 @@ import context from './context';
 import dataSources from './dataSources';
 import onConnect from './onConnect';
 
-export default async (apiSchema: GraphQLSchema): Promise<ApolloServer> => new ApolloServer({
+/**
+ * Builds the Apollo Server from the schema.
+ * @param apiSchema GraphQL schema.
+ * @returns Apollo Server.
+ */
+const apollo = async (apiSchema: GraphQLSchema): Promise<ApolloServer> => new ApolloServer({
   uploads: false,
   schema: apiSchema,
   introspection: true,
@@ -15,3 +20,5 @@ export default async (apiSchema: GraphQLSchema): Promise<ApolloServer> => new Ap
   context: context,
   dataSources: await dataSources(),
 });
+
+export default apollo;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,11 +19,9 @@ class SafeServer {
 
   public status = new EventEmitter();
 
-  constructor(schema: GraphQLSchema) {
-    this.start(schema);
-  }
+  constructor() {}
 
-  public start(schema: GraphQLSchema): void {
+  public async start(schema: GraphQLSchema): Promise<void> {
     // === EXPRESS ===
     this.app = express();
 
@@ -38,7 +36,7 @@ class SafeServer {
     this.app.use('/graphql', graphqlUploadExpress({ maxFileSize: 10000000, maxFiles: 10 }));
 
     // === APOLLO ===
-    this.apolloServer = apollo(schema);
+    this.apolloServer = await apollo(schema);
     this.apolloServer.applyMiddleware({ app: this.app });
 
     // === SUBSCRIPTIONS ===

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,8 +19,6 @@ class SafeServer {
 
   public status = new EventEmitter();
 
-  constructor() {}
-
   public async start(schema: GraphQLSchema): Promise<void> {
     // === EXPRESS ===
     this.app = express();

--- a/src/utils/form/getDisplayText.ts
+++ b/src/utils/form/getDisplayText.ts
@@ -1,5 +1,11 @@
 import { CustomAPI } from '../../server/apollo/dataSources';
 
+/**
+ * Gets display text from choice value.
+ * @param choices list of choices.
+ * @param value choice value.
+ * @returns display value of the value.
+ */
 const getText = (choices: any[], value: any): string => {
   const choice = choices.find(x => x.value ? x.value === value : x === value);
   if (choice && choice.text) {
@@ -8,7 +14,14 @@ const getText = (choices: any[], value: any): string => {
   return value;
 };
 
-export default async (field: any, value: any, context: any): Promise<string | string[]> => {
+/**
+ * Gets display text of a record field, using GraphQL data source mechanism.
+ * @param field field to get value of.
+ * @param value current field value.
+ * @param context provides the data sources context.
+ * @returns Display value of the field value.
+ */
+const getDisplayText = async (field: any, value: any, context: any): Promise<string | string[]> => {
   let choices: any[] = field.choices;
   if (field.choicesByUrl) {
     const url: string = field.choicesByUrl.url;
@@ -35,3 +48,5 @@ export default async (field: any, value: any, context: any): Promise<string | st
   }
   return value;
 };
+
+export default getDisplayText;

--- a/src/utils/form/getDisplayText.ts
+++ b/src/utils/form/getDisplayText.ts
@@ -1,0 +1,37 @@
+import { CustomAPI } from '../../server/apollo/dataSources';
+
+const getText = (choices: any[], value: any): string => {
+  const choice = choices.find(x => x.value ? x.value === value : x === value);
+  if (choice && choice.text) {
+    return choice.text;
+  }
+  return value;
+};
+
+export default async (field: any, value: any, context: any): Promise<string | string[]> => {
+  let choices: any[] = field.choices;
+  if (field.choicesByUrl) {
+    const url: string = field.choicesByUrl.url;
+    if (url.includes('http://localhost:3000/') || url.includes('{SAFE_API}')) {
+      const safeURL: string = url.includes('http://localhost:3000/') ? 'http://localhost:3000/' : '{SAFE_API}';
+      const endpointArray: string[] = url.substring(url.indexOf(safeURL) + safeURL.length).split('/');
+      const apiName: string = endpointArray.shift();
+      const endpoint: string = endpointArray.join('/');
+      const dataSource: CustomAPI = context.dataSources[apiName];
+      if (dataSource) {
+        choices = await dataSource.getChoices(endpoint, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
+      }
+    } else {
+      const dataSource: CustomAPI = context.dataSources._rest;
+      choices = await dataSource.getChoices(url, field.choicesByUrl.path, field.choicesByUrl.value, field.choicesByUrl.text);
+    }
+  }
+  if (choices && choices.length) {
+    if (Array.isArray(value)) {
+      return value.map(x => getText(choices, x));
+    } else {
+      return getText(choices, value);
+    }
+  }
+  return value;
+};

--- a/src/utils/schema/introspection/getSchema.ts
+++ b/src/utils/schema/introspection/getSchema.ts
@@ -1,4 +1,4 @@
-import { extendSchema, GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString, parse } from 'graphql';
+import { extendSchema, GraphQLBoolean, GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString, parse } from 'graphql';
 import { pluralize } from 'inflection';
 import { SchemaStructure } from '../getStructures';
 import getTypes from './getTypes';
@@ -80,6 +80,7 @@ export const getSchema = (structures: SchemaStructure[]) => {
         type: typesByName[x.name],
         args: {
           id: { type: new GraphQLNonNull(GraphQLID) },
+          display: { type: GraphQLBoolean },
         },
       };
       // === MULTI ENTITIES ===
@@ -92,6 +93,7 @@ export const getSchema = (structures: SchemaStructure[]) => {
           sortField: { type: GraphQLString },
           sortOrder: { type: GraphQLString },
           filter: { type: GraphQLJSON },
+          display: { type: GraphQLBoolean },
           // filter: { type: filterTypesByName[getGraphQLFilterTypeName(x.name)] },
         },
       };

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -8,6 +8,7 @@ import { defaultRecordFieldsFlat } from '../../../../const/defaultRecordFields';
 import { getFormPermissionFilter } from '../../../filter';
 import { AppAbility } from '../../../../security/defineAbilityFor';
 import { GraphQLID, GraphQLList } from 'graphql';
+import getDisplayText from '../../../form/getDisplayText';
 
 export const getEntityResolver = (name: string, data, id: string, ids) => {
 
@@ -59,11 +60,17 @@ export const getEntityResolver = (name: string, data, id: string, ids) => {
   const classicResolvers = entityFields.filter(x => !defaultRecordFieldsFlat.includes(x)).reduce(
     (resolvers, fieldName) =>
       Object.assign({}, resolvers, {
-        [fieldName]: (entity) => {
+        [fieldName]: (entity, _, context) => {
           const field = fields[fieldName];
           const value = relationshipFields.includes(fieldName) ?
             entity.data[fieldName.substr(0, fieldName.length - (fieldName.endsWith('_id') ? 3 : 4))] :
             entity.data[fieldName];
+          if (entity.display) {
+            const formField = entity.fields.find(x => x.name === fieldName);
+            if (formField.choices || formField.choicesByUrl) {
+              return getDisplayText(formField, value, context);
+            }
+          }
           return field.type === 'String' ? value.toString() : value;
         },
       }),

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -18,6 +18,7 @@ export default (id, data) => async (
     skip = 0,
     afterCursor,
     filter = {},
+    display = false,
   },
   context,
 ) => {
@@ -43,7 +44,13 @@ export default (id, data) => async (
     },
   } : {};
 
-  let items: any[] = [];
+  // Get fields if we want to display with text
+  let fields: any[];
+  if (display) {
+    fields = (await Form.findOne({ $or: [{ _id: id }, { resource: id, core: true }] }).select('fields')).fields;
+  }
+
+  let items: Record[] = [];
   let filters: any = {};
   // Filter from the user permissions
   let permissionFilters = [];
@@ -87,7 +94,7 @@ export default (id, data) => async (
   }
   const edges = items.map(r => ({
     cursor: encodeCursor(r.id.toString()),
-    node: r,
+    node: display ? Object.assign(r, { display, fields }) : r,
   }));
   return {
     pageInfo: {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -45,7 +45,7 @@ export default (id, data) => async (
   } : {};
 
   // Get fields if we want to display with text
-  let fields: any[];
+  let fields: any[] = [];
   if (display) {
     fields = (await Form.findOne({ $or: [{ _id: id }, { resource: id, core: true }] }).select('fields')).fields;
   }

--- a/src/utils/schema/resolvers/Query/single.ts
+++ b/src/utils/schema/resolvers/Query/single.ts
@@ -1,11 +1,16 @@
 import { GraphQLError } from 'graphql';
 import errors from '../../../../const/errors';
-import { Record } from '../../../../models';
+import { Record, Form } from '../../../../models';
 
-export default () => (_, { id }, context) => {
+export default () => async (_, { id, display }, context) => {
   const user = context.user;
   if (!user) {
     throw new GraphQLError(errors.userNotLogged);
   }
-  return Record.findOne({ _id: id, archived: { $ne: true } });
+  const record: any = await Record.findOne({ _id: id, archived: { $ne: true } });
+  if (display) {
+    record.display = display;
+    record.fields = (await Form.findById(record.form, 'fields')).fields;
+  }
+  return record;
 };


### PR DESCRIPTION
# Description

Added datasources for apiConfigurations: 
https://medium.com/paypal-tech/graphql-resolvers-best-practices-cd36fdbcef55
https://www.apollographql.com/docs/apollo-server/data/data-sources/

Unfortunately, async initialization is not yet supported: 
https://github.com/apollographql/apollo-server/pull/4222

Added `display` arguments for query involving records data. When passed, we return the text instead of the value for all fields with choices.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with questions using:
- Hardcoded choices in the `{ value: any, text: string }` format
- Choices from public REST endpoint
- Choices from APIConfiguration
- Multiple selection

Tested all in playground and in the front end..

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
