### PR TITLE
AB#11672

### DIFF
--- a/src/schema/mutation/editForm.ts
+++ b/src/schema/mutation/editForm.ts
@@ -101,7 +101,7 @@ export default {
                       ((x.hasOwnProperty('defaultValue') && (x.defaultValue !== oldField.defaultValue)) ? // If the child possesses the "defaultValue" property
                         { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
                         : field) // Else replace child's field by parent's field
-                      : x // Else don't change the child's field
+                      : x; // Else don't change the child's field
                   });
 
                   // Update structure

--- a/src/schema/mutation/editForm.ts
+++ b/src/schema/mutation/editForm.ts
@@ -96,11 +96,20 @@ export default {
                 // === REFLECT UPDATE ===
                 for (const childForm of childForms) { // For each form that inherits from the same resource
 
-                  childForm.fields = childForm.fields.map(x => x.name === field.name ? field : x); // If there's a field sharing the same name in the childForm, replace it by the new field -- TODO Can't this be optimized ?
+                  childForm.fields = childForm.fields.map(x => { // For each field of the childForm
+                    return (x.name === field.name) ? // If the child field's name equals the parent field's name
+                      ((x.hasOwnProperty('defaultValue') && (x.defaultValue !== oldField.defaultValue)) ? // If the child possesses the "defaultValue" property
+                        { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                        : field) // Else replace child's field by parent's field
+                      : x // Else don't change the child's field
+                  });
 
                   // Update structure
                   const newStructure = JSON.parse(childForm.structure); // Get the inheriting form's structure
-                  replaceField(newStructure, field.name, structure); // Replace the inheriting form's field by the edited form's field 
+                  const prevStructure = JSON.parse(form.structure); // Get the current form's state structure
+
+                  replaceField(field.name, newStructure, structure, prevStructure); // Replace the inheriting form's field by the edited form's field
+
                   childForm.structure = JSON.stringify(newStructure); // Save the new structure
                   // Update form
                   const formUpdate = {

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -25,6 +25,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
           isRequired: element.isRequired ? element.isRequired : false,
           readOnly: element.readOnly ? element.readOnly : false,
           isCore: core,
+          ...(element.hasOwnProperty('defaultValue') ? { defaultValue: element.defaultValue } : {})
         };
         // ** Resource **
         if (element.type === 'resource' || element.type === 'resources') {
@@ -34,10 +35,10 @@ export const extractFields = async (object, fields, core): Promise<void> => {
               displayField: element.displayField,
               relatedName: element.relatedName,
             },
-            element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
-            element.canAddNew && { canAddNew: element.canAddNew },
-            element.addTemplate && { addTemplate: element.addTemplate },
-            element.gridFieldsSettings && { gridFieldsSettings: element.gridFieldsSettings },
+              element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
+              element.canAddNew && { canAddNew: element.canAddNew },
+              element.addTemplate && { addTemplate: element.addTemplate },
+              element.gridFieldsSettings && { gridFieldsSettings: element.gridFieldsSettings },
             );
           } else {
             throw new GraphQLError(errors.missingRelatedField(element.valueName));
@@ -116,18 +117,22 @@ export const extractFields = async (object, fields, core): Promise<void> => {
         // ** Dropdown / Radio / Checkbox / Tagbox **
         if (field.type === 'dropdown' || field.type === 'radiogroup' || field.type === 'checkbox' || field.type === 'tagbox') {
           Object.assign(field, {
-            ...!element.choicesByUrl && { choices: element.choices.map(x => {
-              return x.value ? {
-                value: x.value ? x.value : x,
-                text: x.text ? x.text : x,
-              } : x;
-            }) },
-            ...element.choicesByUrl && { choicesByUrl: {
-              url: element.choicesByUrl.url ? element.choicesByUrl.url : element.choicesByUrl,
-              ...element.choicesByUrl.path && { path: element.choicesByUrl.path },
-              value: element.choicesByUrl.valueName ? element.choicesByUrl.valueName : 'name',
-              text: element.choicesByUrl.titleName ? element.choicesByUrl.titleName : 'name',
-            } },
+            ...!element.choicesByUrl && {
+              choices: element.choices.map(x => {
+                return x.value ? {
+                  value: x.value ? x.value : x,
+                  text: x.text ? x.text : x,
+                } : x;
+              })
+            },
+            ...element.choicesByUrl && {
+              choicesByUrl: {
+                url: element.choicesByUrl.url ? element.choicesByUrl.url : element.choicesByUrl,
+                ...element.choicesByUrl.path && { path: element.choicesByUrl.path },
+                value: element.choicesByUrl.valueName ? element.choicesByUrl.valueName : 'name',
+                text: element.choicesByUrl.titleName ? element.choicesByUrl.titleName : 'name',
+              }
+            },
           });
         }
         // ** Owner **

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -25,7 +25,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
           isRequired: element.isRequired ? element.isRequired : false,
           readOnly: element.readOnly ? element.readOnly : false,
           isCore: core,
-          ...(element.hasOwnProperty('defaultValue') ? { defaultValue: element.defaultValue } : {})
+          ...(element.hasOwnProperty('defaultValue') ? { defaultValue: element.defaultValue } : {}),
         };
         // ** Resource **
         if (element.type === 'resource' || element.type === 'resources') {
@@ -35,10 +35,10 @@ export const extractFields = async (object, fields, core): Promise<void> => {
               displayField: element.displayField,
               relatedName: element.relatedName,
             },
-              element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
-              element.canAddNew && { canAddNew: element.canAddNew },
-              element.addTemplate && { addTemplate: element.addTemplate },
-              element.gridFieldsSettings && { gridFieldsSettings: element.gridFieldsSettings },
+            element.displayAsGrid && { displayAsGrid: element.displayAsGrid },
+            element.canAddNew && { canAddNew: element.canAddNew },
+            element.addTemplate && { addTemplate: element.addTemplate },
+            element.gridFieldsSettings && { gridFieldsSettings: element.gridFieldsSettings },
             );
           } else {
             throw new GraphQLError(errors.missingRelatedField(element.valueName));
@@ -123,7 +123,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
                   value: x.value ? x.value : x,
                   text: x.text ? x.text : x,
                 } : x;
-              })
+              }),
             },
             ...element.choicesByUrl && {
               choicesByUrl: {
@@ -131,7 +131,7 @@ export const extractFields = async (object, fields, core): Promise<void> => {
                 ...element.choicesByUrl.path && { path: element.choicesByUrl.path },
                 value: element.choicesByUrl.valueName ? element.choicesByUrl.valueName : 'name',
                 text: element.choicesByUrl.titleName ? element.choicesByUrl.titleName : 'name',
-              }
+              },
             },
           });
         }

--- a/src/utils/form/replaceField.ts
+++ b/src/utils/form/replaceField.ts
@@ -17,13 +17,13 @@ export const replaceField = (fieldName: string, editedStructure: any, referenceS
     }
   } else if (editedStructure.elements) {
     for (const elementIndex in editedStructure.elements) {
-      let element = editedStructure.elements[elementIndex];
+      const element = editedStructure.elements[elementIndex];
       if (element.type === 'panel') {
         if (replaceField(fieldName, element, referenceStructure, prevReferenceStructure)) return true;
       } else {
         if (element.valueName === fieldName) {
-          const referenceField = getQuestion(referenceStructure, fieldName)
-          const prevReferenceField = getQuestion(prevReferenceStructure, fieldName)
+          const referenceField = getQuestion(referenceStructure, fieldName);
+          const prevReferenceField = getQuestion(prevReferenceStructure, fieldName);
 
           // If the edited structure's field has a defaultValue, and this defaultValue
           // isn't equal to the previous version of the reference structure's field's defaultValue
@@ -32,7 +32,7 @@ export const replaceField = (fieldName: string, editedStructure: any, referenceS
             editedStructure.elements[elementIndex] = { ...referenceField, defaultValue: element.defaultValue };
           } else {
             // Completely replace the edited structure's field by the reference structure's field
-            editedStructure.elements[elementIndex] = referenceField
+            editedStructure.elements[elementIndex] = referenceField;
           }
 
           return true;


### PR DESCRIPTION
# Description

!!! Bug found !!! Do not review / merge yet

When a field is modified on a form core, some of the changes are applied to the field in all the forms inheriting it.
This didn't include the defaultValue.
The goal of this PR is to modify this behavior so that the defaultValue is inherited from the core form's changes.
However, if an inheriting form's field has a "defaultValue" attribute set by the user, then it shouldn't be overridden.

The current behaviour is that, when a field's defaultValue is changed on the core form, the change is applied on the same field for all the children forms, only if their defaultValue is the same as was for the core form.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- [x] Add a defaultValue to a core form's field and check that the value is applied to all children
- [x] Modify the default value of a children form's field
- [x] Modify the defaultValue of the core form's field and check that the change is correctly applied on all children form's fields except the one which had its defaultValue modified earlier
- [x] Delete the defaultValue of the core form's field and check that the change is correctly applied on all children form's fields except the one which had its defaultValue modified earlier

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
